### PR TITLE
修复basename造成的问题

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -173,7 +173,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
     if (match) {
       const { path, basename } = element.props as any;
 
-      setIcestark('basename', basename || (Array.isArray(path) ? path[0] : path));
+      basename && setIcestark('basename', basename);
 
       realComponent = React.cloneElement(element, extraProps);
     } else {


### PR DESCRIPTION
如果basename没有传递，不应该设置basename，会影响@ice/stark-router 中针对react-router设置basename