### PR TITLE
fix: set value to original window

### DIFF
--- a/packages/icestark-sandbox/package.json
+++ b/packages/icestark-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/sandbox",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "sandbox for execute scripts",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/icestark-sandbox/tests/index.spec.ts
+++ b/packages/icestark-sandbox/tests/index.spec.ts
@@ -6,6 +6,8 @@ describe('sandbox', () => {
 
   test('execute script in sandbox', () => {
     sandbox.execScriptInSandbox('window.a = 1;expect(window.a).toBe(1);');
+    expect((window as any).a).toBe(1);
+    sandbox.clear();
     expect((window as any).a).toBe(undefined);
   });
 


### PR DESCRIPTION
### 原因
在一些场景下面，脚本的执行会跳出沙箱，比如 jsonp 的执行和 js bundle 的加载，因此新增/修改属性需要直接挂载在 window 上，通过 proxy 记录的修改在沙箱卸载时还原