### PR TITLE
资源加载失败时候的错误信息优化

### DIFF
--- a/src/util/handleAssets.ts
+++ b/src/util/handleAssets.ts
@@ -74,7 +74,7 @@ export function appendCSS(
     element.addEventListener(
       'error',
       () => {
-        error(`css asset loaded error: ${asset}`);
+        error(`css asset loaded error: ${content || asset}`);
         return resolve();
       },
       false,
@@ -113,7 +113,7 @@ export function appendExternalScript(
 
     element.addEventListener(
       'error',
-      () => reject(new Error(`js asset loaded error: ${asset}`)),
+      () => reject(new Error(`js asset loaded error: ${content || asset}`)),
       false,
     );
     element.addEventListener('load', () => resolve(), false);


### PR DESCRIPTION
资源加载失败时候的错误信息优化：
原先： js asset loaded error: [object Object]
修改后：js asset loaded error: https://example.com/xxx.js