### PR TITLE
优化加载css和js资源的顺序，提升页面性能

### DIFF
--- a/src/util/handleAssets.ts
+++ b/src/util/handleAssets.ts
@@ -166,8 +166,10 @@ export function fetchScripts(jsList: Asset[], fetch: Fetch = winFetch) {
   }));
 }
 export async function appendAssets(assets: Assets, sandbox?: Sandbox) {
-  await loadAndAppendCssAssets(assets);
-  await loadAndAppendJsAssets(assets, sandbox);
+  await Promise.all([
+    loadAndAppendCssAssets(assets),
+    loadAndAppendJsAssets(assets, sandbox),
+  ]);
 }
 
 export function parseUrl(entry: string): ParsedConfig {


### PR DESCRIPTION
css资源可以和js的资源同时处理，不必要等css加载完成之后再加载js，同时处理可以提升页面性能，尤其在复杂的大型项目中，处理css资源比较耗时的情况下