### PR TITLE
feat: applink支持自定义标签类型

### DIFF
--- a/src/AppLink.tsx
+++ b/src/AppLink.tsx
@@ -6,28 +6,29 @@ export type AppLinkProps = {
   replace?: boolean;
   message?: string;
   children?: React.ReactNode;
+  tag?: string;
 } & React.AnchorHTMLAttributes<any>;
 
 const AppLink: React.SFC<AppLinkProps> = (props: AppLinkProps) => {
-  const { to, hashType, replace, message, children, ...rest } = props;
+  const { to, hashType, replace, message, children, tag, ...rest } = props;
   const linkTo = hashType && to.indexOf('#') === -1 ? `/#${to}` : to;
-  return (
-    <a
-      {...rest}
-      href={linkTo}
-      onClick={e => {
+
+  return React.createElement(
+    tag ?? 'a',
+    Object.assign({}, rest, {
+      href: linkTo,
+      onClick: (e) => {
         e.preventDefault();
+
         if (message && window.confirm(message) === false) {
           return false;
         }
 
         const changeState = window.history[replace ? 'replaceState' : 'pushState'];
-
         changeState({}, null, linkTo);
-      }}
-    >
-      {children}
-    </a>
+      },
+    }),
+    children,
   );
 };
 


### PR DESCRIPTION
需求原因：
淘宝直播PC中控台使用icestark + fusion，如果子应用中使用fusion reset.css，其中的a标签reset会污染全局的样式，然而这并不可控。

解决方案：
1. 二方和组内成员约定规范，避开AppLink的使用，统一使用history.push代码跳转。
2. AppLink标签支持自定义tag，比如div或span，reset基本不会去设置额外样式，不会造成污染。