### PR TITLE
 fix: fix create-react-app access to micro app docs error

### DIFF
--- a/website/docs/guide/use-child/others.md
+++ b/website/docs/guide/use-child/others.md
@@ -50,7 +50,7 @@ import App from './App';
 
 + setLibraryName('microApp');
 
-+ if (!isInIcestark) {
++ if (!isInIcestark()) {
     ReactDOM.render(
       <React.StrictMode>
         <App />


### PR DESCRIPTION
Fix documentation errors on this page
https://micro-frontends.ice.work/docs/guide/use-child/others#create-react-app-%E5%BA%94%E7%94%A8