### PR TITLE
Fix/empty active path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See [https://github.com/ice-lab/icestark/releases](https://github.com/ice-lab/icestark/releases) for what has changed in each version of icestark.
 
+## 2.5.3
+
+- [fix] `setBasename` before `createMicroApp` may be covered for empty activePath.
+
 ## 2.5.2
 
 - [fix] `createMicroApp` without `activePath` cause error.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/stark",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Icestark is a JavaScript library for multiple projects, Ice workbench solution.",
   "scripts": {
     "install:deps": "rm -rf node_modules && rm -rf ./packages/*/node_modules && yarn install && lerna exec -- npm install",

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -14,7 +14,7 @@ import {
 import { setCache } from './util/cache';
 import { loadBundle } from './util/loader';
 import { getLifecyleByLibrary, getLifecyleByRegister } from './util/getLifecycle';
-import { mergeFrameworkBaseToPath, getAppBasename, isFunction } from './util/helpers';
+import { mergeFrameworkBaseToPath, getAppBasename, isFunction, shouldSetBasename } from './util/helpers';
 import globalConfiguration from './util/globalConfiguration';
 import type { StartConfiguration } from './util/globalConfiguration';
 
@@ -261,7 +261,7 @@ export async function createMicroApp(app: string | AppConfig, appLifecyle?: AppL
 
     const { basename: frameworkBasename } = userConfiguration;
 
-    if (!isFunction(activePath)) {
+    if (shouldSetBasename(activePath, basename)) {
       setCache('basename', getAppBasename(activePath, frameworkBasename, basename));
     }
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,4 +1,4 @@
-import type { PathData, AppRoutePath, ActiveFn } from './checkActive';
+import type { PathData, AppRoutePath, ActiveFn, ActivePath } from './checkActive';
 
 export const isDev = process.env.NODE_ENV === 'development';
 
@@ -61,6 +61,11 @@ export const isFunction = (value: unknown): value is Function => {
  * Checks if value is a plain object.
  */
 export const isObject = checkTypes('Object');
+
+/**
+ * Checks if value is underfined.
+ */
+export const isUndefined = checkTypes('Undefined');
 
 /**
  * convert path to unique string.
@@ -127,4 +132,20 @@ export const mergeFrameworkBaseToPath = (path: PathData[] | ActiveFn, frameworkB
     }));
   }
   return path;
+};
+
+/**
+ * Check basename should set or not. Especially, one may use `createMicroApp` without `activePath` and
+ * `basename` setting.
+ */
+export const shouldSetBasename = (activePath?: ActivePath, basenmae?: string): activePath is AppRoutePath => {
+  if (isFunction(activePath)) {
+    return false;
+  }
+
+  if (isUndefined(activePath) && isUndefined(basenmae)) {
+    return false;
+  }
+
+  return true;
 };

--- a/tests/AppRouter.spec.tsx
+++ b/tests/AppRouter.spec.tsx
@@ -42,6 +42,8 @@ describe('AppRouter', () => {
     window.history.pushState({}, 'test', '/seller/detail');
     await delay(1000);
     expect(container.innerHTML).toContain('商家详情')
+
+    unmount();
   })
 
   test('app-basename-custom', async () => {

--- a/tests/AppRouter.spec.tsx
+++ b/tests/AppRouter.spec.tsx
@@ -14,7 +14,7 @@ describe('AppRouter', () => {
   const umdSourceWithSetLibrary = fs.readFileSync(path.resolve(__dirname, './umd-setlibrary-sample.js'));
   beforeEach(() => {
     (fetch as FetchMock).resetMocks();
-    setCache('root', true);
+    setCache('basename', '');
   });
 
   test('app-basename-default', async () => {

--- a/tests/createMicroApp.spec.tsx
+++ b/tests/createMicroApp.spec.tsx
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { FetchMock } from 'jest-fetch-mock';
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { createMicroApp, unmountMicroApp } from '../src/apps';
+import { setCache, getCache } from '../src/util/cache';
+
+describe('createMicroApp', () => {
+  const umdSourceWithSetLibrary = fs.readFileSync(path.resolve(__dirname, './umd-setlibrary-sample.js'));
+  beforeEach(() => {
+    (fetch as FetchMock).resetMocks();
+    setCache('basename', '');
+  });
+
+  // before 2.5.0, createMicroApp did not support basename
+  test('old-app-basename', async () => {
+    (fetch as FetchMock).mockResponseOnce(umdSourceWithSetLibrary.toString());
+
+    const { getByTestId, container, unmount } = render(<div data-testid="container"></div>)
+
+    // use setBasename instead
+    setCache('basename', '/seller');
+
+    await createMicroApp({
+      name: 'waiter',
+      url:[
+        '//icestark.com/index.js'
+      ],
+      container: getByTestId('container'),
+      loadScriptMode: "fetch"
+    })
+
+    console.log('fsdff', getCache('basename'))
+    expect(getCache('basename')).toEqual('/seller');
+    expect(!!getCache('root')).toBeTruthy();
+    expect(container.innerHTML).toContain('商家列表')
+
+    unmountMicroApp('waiter')
+    unmount();
+  })
+
+  test('app-basename', async () => {
+    (fetch as FetchMock).mockResponseOnce(umdSourceWithSetLibrary.toString());
+
+    const { getByTestId, container, unmount } = render(<div data-testid="container"></div>)
+    await createMicroApp({
+      name: 'seller',
+      basename: "seller",
+      url:[
+        '//icestark.com/index.js'
+      ],
+      container: getByTestId('container'),
+      loadScriptMode: "fetch"
+    })
+
+    expect(getCache('basename')).toEqual('/seller');
+    expect(!!getCache('root')).toBeTruthy();
+    expect(container.innerHTML).toContain('商家列表');
+
+    unmountMicroApp('seller');
+    unmount();
+  })
+})


### PR DESCRIPTION
- [x] `setBasename` before `createMicroApp` may be covered for empty activePath.