### PR TITLE
fix(icestark): fix isAssetExist type statement

### DIFF
--- a/packages/icestark/src/util/handleAssets.ts
+++ b/packages/icestark/src/util/handleAssets.ts
@@ -57,7 +57,7 @@ export interface ILifecycleProps {
   customProps?: object;
 }
 
-function isAssetExist(element: HTMLScriptElement | HTMLLIElement, type: 'script' | 'link') {
+function isAssetExist(element: HTMLScriptElement | HTMLLinkElement, type: 'script' | 'link') {
   const urlAlias = type === 'script' ? 'src' : 'href';
 
   return Array.from(document.getElementsByTagName(type))


### PR DESCRIPTION
Modify the isAssetExist  function parameter element type to HTMLScriptElement | HTMLLinkElement