### PR TITLE
fix: 🐛 set actual basename when `activePath` is an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See [https://github.com/ice-lab/icestark/releases](https://github.com/ice-lab/icestark/releases) for what has changed in each version of icestark.
 
+## 2.7.2
+
+- [fix] set actual basename when `activePath` is an array. ([#526](https://github.com/ice-lab/icestark/issues/526))
+
 ## 2.7.1
 
 - [feat] improve DX a lot.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icestark-monorepo",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "description": "Icestark is a JavaScript library for multiple projects, Ice workbench solution.",
   "scripts": {

--- a/packages/icestark/__tests__/AppRouter.spec.tsx
+++ b/packages/icestark/__tests__/AppRouter.spec.tsx
@@ -120,4 +120,30 @@ describe('AppRouter', () => {
 
     unmount();
   })
+
+
+  test('app-multi-paths', async () => {
+    (fetch as FetchMock).mockResponseOnce(umdSourceWithSetLibrary.toString());
+    const { container, unmount } = render(
+      <AppRouter>
+        <AppRoute
+          loadScriptMode="fetch"
+          name="seller"
+          path={["/seller", "/seller2"]}
+          title="小二"
+          url={[
+            '//icestark.com/index.js'
+          ]}
+        />
+      </AppRouter>
+    );
+    window.history.pushState({}, 'test', '/seller2');
+    expect(container.innerHTML).toContain('Loading')
+    expect(getCache('basename')).toBe('/seller2');
+
+    await delay(1000);
+    expect(container.innerHTML).toContain('商家平台')
+
+    unmount();
+  })
 })

--- a/packages/icestark/__tests__/checkActive.spec.tsx
+++ b/packages/icestark/__tests__/checkActive.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect';
-import findActivePathIndex, { matchPath, getPathname, formatPath } from '../src/util/checkActive';
+import findActivePath, { matchPath, getPathname, formatPath } from '../src/util/checkActive';
 
 describe('checkActive', () => {
   test('matchPath - path options', () => {
@@ -54,48 +54,48 @@ describe('checkActive', () => {
 
   test('checkActive', () => {
     // empty activePath
-    let checkFnc = findActivePathIndex();
-    expect(checkFnc('/test/123')).toEqual(0);
+    let checkFnc = findActivePath();
+    expect(checkFnc('/test/123')).toBeTruthy();
 
     // type `string`
-    checkFnc = findActivePathIndex(formatPath('/test', {}));
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath(formatPath('/test', {}));
+    expect(checkFnc('/test/123')).toEqual('/test');
 
-    checkFnc = findActivePathIndex(formatPath('/test', { exact: true }));
-    expect(checkFnc('/test/123')).toEqual(-1);
+    checkFnc = findActivePath(formatPath('/test', { exact: true }));
+    expect(checkFnc('/test/123')).toBeFalsy();
 
     // type `string[]`
-    checkFnc = findActivePathIndex(formatPath(['/test', '/seller'], {}));
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath(formatPath(['/test', '/seller'], {}));
+    expect(checkFnc('/test/123')).toEqual('/test');
 
-    checkFnc = findActivePathIndex(formatPath(['/test', '/seller'], { exact: true }));
-    expect(checkFnc('/test/123')).toEqual(-1);
+    checkFnc = findActivePath(formatPath(['/test', '/seller'], { exact: true }));
+    expect(checkFnc('/test/123')).toBeFalsy();
 
     // type `PathData`
-    checkFnc = findActivePathIndex(formatPath({ value: '/test' }, {}));
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath(formatPath({ value: '/test' }, {}));
+    expect(checkFnc('/test/123')).toEqual('/test');
 
-    checkFnc = findActivePathIndex(formatPath({ value: '/test', exact: true }, {}));
-    expect(checkFnc('/test/123')).toEqual(-1)
+    checkFnc = findActivePath(formatPath({ value: '/test', exact: true }, {}));
+    expect(checkFnc('/test/123')).toBeFalsy();
 
     // type `PathData[]`
-    checkFnc = findActivePathIndex([{ value: '/test' }, { value: '/seller' }]);
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath([{ value: '/test' }, { value: '/seller' }]);
+    expect(checkFnc('/test/123')).toEqual('/test');
 
     // type `MixedPathData`
-    checkFnc = findActivePathIndex(formatPath(['/test', { value: '/seller' }]));
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath(formatPath(['/test', { value: '/seller' }]));
+    expect(checkFnc('/test/123')).toEqual('/test');
 
     // type `ActiveFn`
-    checkFnc = findActivePathIndex((url: string) => url.includes('/test'));
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath((url: string) => url.includes('/test'));
+    expect(checkFnc('/test/123')).toBeTruthy();
 
     // `undefined`
-    checkFnc = findActivePathIndex(formatPath());
-    expect(checkFnc('/test/123')).toEqual(0);
+    checkFnc = findActivePath(formatPath());
+    expect(checkFnc('/test/123')).toBeTruthy();
 
     // matched idx
-    checkFnc = findActivePathIndex(formatPath(['/test', '/seller'], {}));
-    expect(checkFnc('/seller')).toEqual(1);
+    checkFnc = findActivePath(formatPath(['/test', '/seller'], {}));
+    expect(checkFnc('/seller')).toEqual('/seller');
   })
 });

--- a/packages/icestark/__tests__/checkActive.spec.tsx
+++ b/packages/icestark/__tests__/checkActive.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect';
-import checkActive, { matchPath, getPathname, formatPath } from '../src/util/checkActive';
+import findActivePathIndex, { matchPath, getPathname, formatPath } from '../src/util/checkActive';
 
 describe('checkActive', () => {
   test('matchPath - path options', () => {
@@ -54,60 +54,48 @@ describe('checkActive', () => {
 
   test('checkActive', () => {
     // empty activePath
-    let checkFnc = checkActive();
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    let checkFnc = findActivePathIndex();
+    expect(checkFnc('/test/123')).toEqual(0);
 
     // type `string`
-    checkFnc = checkActive(formatPath('/test', {}));
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath('/test', {}));
+    expect(checkFnc('/test/123')).toEqual(0);
 
-    checkFnc = checkActive(formatPath('/test', { exact: true }));
-    expect(checkFnc('/test/123')[0]).toBeFalsy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath('/test', { exact: true }));
+    expect(checkFnc('/test/123')).toEqual(-1);
 
     // type `string[]`
-    checkFnc = checkActive(formatPath(['/test', '/seller'], {}));
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath(['/test', '/seller'], {}));
+    expect(checkFnc('/test/123')).toEqual(0);
 
-    checkFnc = checkActive(formatPath(['/test', '/seller'], { exact: true }));
-    expect(checkFnc('/test/123')[0]).toBeFalsy();
-    expect(checkFnc('/test/123')[1]).toEqual(1);
+    checkFnc = findActivePathIndex(formatPath(['/test', '/seller'], { exact: true }));
+    expect(checkFnc('/test/123')).toEqual(-1);
 
     // type `PathData`
-    checkFnc = checkActive(formatPath({ value: '/test' }, {}));
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath({ value: '/test' }, {}));
+    expect(checkFnc('/test/123')).toEqual(0);
 
-    checkFnc = checkActive(formatPath({ value: '/test', exact: true }, {}));
-    expect(checkFnc('/test/123')[0]).toBeFalsy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath({ value: '/test', exact: true }, {}));
+    expect(checkFnc('/test/123')).toEqual(-1)
 
     // type `PathData[]`
-    checkFnc = checkActive([{ value: '/test' }, { value: '/seller' }]);
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex([{ value: '/test' }, { value: '/seller' }]);
+    expect(checkFnc('/test/123')).toEqual(0);
 
     // type `MixedPathData`
-    checkFnc = checkActive(formatPath(['/test', { value: '/seller' }]));
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath(['/test', { value: '/seller' }]));
+    expect(checkFnc('/test/123')).toEqual(0);
 
     // type `ActiveFn`
-    checkFnc = checkActive((url: string) => url.includes('/test'));
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex((url: string) => url.includes('/test'));
+    expect(checkFnc('/test/123')).toEqual(0);
 
     // `undefined`
-    checkFnc = checkActive(formatPath());
-    expect(checkFnc('/test/123')[0]).toBeTruthy();
-    expect(checkFnc('/test/123')[1]).toEqual(0);
+    checkFnc = findActivePathIndex(formatPath());
+    expect(checkFnc('/test/123')).toEqual(0);
 
     // matched idx
-    checkFnc = checkActive(formatPath(['/test', '/seller'], {}));
-    expect(checkFnc('/seller')[0]).toBeTruthy();
-    expect(checkFnc('/seller')[1]).toEqual(1);
+    checkFnc = findActivePathIndex(formatPath(['/test', '/seller'], {}));
+    expect(checkFnc('/seller')).toEqual(1);
   })
 });

--- a/packages/icestark/__tests__/checkActive.spec.tsx
+++ b/packages/icestark/__tests__/checkActive.spec.tsx
@@ -55,43 +55,59 @@ describe('checkActive', () => {
   test('checkActive', () => {
     // empty activePath
     let checkFnc = checkActive();
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     // type `string`
     checkFnc = checkActive(formatPath('/test', {}));
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     checkFnc = checkActive(formatPath('/test', { exact: true }));
-    expect(checkFnc('/test/123')).toBeFalsy();
+    expect(checkFnc('/test/123')[0]).toBeFalsy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     // type `string[]`
     checkFnc = checkActive(formatPath(['/test', '/seller'], {}));
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     checkFnc = checkActive(formatPath(['/test', '/seller'], { exact: true }));
-    expect(checkFnc('/test/123')).toBeFalsy();
+    expect(checkFnc('/test/123')[0]).toBeFalsy();
+    expect(checkFnc('/test/123')[1]).toEqual(1);
 
     // type `PathData`
     checkFnc = checkActive(formatPath({ value: '/test' }, {}));
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     checkFnc = checkActive(formatPath({ value: '/test', exact: true }, {}));
-    expect(checkFnc('/test/123')).toBeFalsy();
+    expect(checkFnc('/test/123')[0]).toBeFalsy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     // type `PathData[]`
     checkFnc = checkActive([{ value: '/test' }, { value: '/seller' }]);
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     // type `MixedPathData`
     checkFnc = checkActive(formatPath(['/test', { value: '/seller' }]));
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     // type `ActiveFn`
     checkFnc = checkActive((url: string) => url.includes('/test'));
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
 
     // `undefined`
     checkFnc = checkActive(formatPath());
-    expect(checkFnc('/test/123')).toBeTruthy();
+    expect(checkFnc('/test/123')[0]).toBeTruthy();
+    expect(checkFnc('/test/123')[1]).toEqual(0);
+
+    // matched idx
+    checkFnc = checkActive(formatPath(['/test', '/seller'], {}));
+    expect(checkFnc('/seller')[0]).toBeTruthy();
+    expect(checkFnc('/seller')[1]).toEqual(1);
   })
 });

--- a/packages/icestark/package.json
+++ b/packages/icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/stark",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Icestark is a JavaScript library for multiple projects, Ice workbench solution.",
   "scripts": {
     "build": "rm -rf lib && tsc",

--- a/packages/icestark/src/AppRoute.tsx
+++ b/packages/icestark/src/AppRoute.tsx
@@ -3,9 +3,10 @@ import renderComponent from './util/renderComponent';
 import { AppHistory } from './appHistory';
 import { unloadMicroApp, BaseConfig, createMicroApp } from './apps';
 import { converArray2String } from './util/helpers';
-import { PathData } from './util/checkActive';
 import { callCapturedEventListeners, resetCapturedEventListeners } from './util/capturedListeners';
 import isEqual from 'lodash.isequal';
+
+import type { PathData } from './util/checkActive';
 
 interface AppRouteState {
   showComponent: boolean;

--- a/packages/icestark/src/AppRouter.tsx
+++ b/packages/icestark/src/AppRouter.tsx
@@ -227,7 +227,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
 
         element = child;
 
-        match = checkActive(compatPath)(url);
+        match = checkActive(compatPath)(url)[0];
       }
     });
 

--- a/packages/icestark/src/AppRouter.tsx
+++ b/packages/icestark/src/AppRouter.tsx
@@ -7,7 +7,7 @@ import { ICESTSRK_ERROR, ICESTSRK_NOT_FOUND } from './util/constant';
 import start, { unload } from './start';
 import { AppConfig, MicroApp } from './apps';
 import { doPrefetch, Prefetch } from './util/prefetch';
-import checkActive, { AppRoutePath, formatPath } from './util/checkActive';
+import findActivePathIndex, { AppRoutePath, formatPath } from './util/checkActive';
 import { converArray2String, isFunction, mergeFrameworkBaseToPath } from './util/helpers';
 import type { Fetch } from './util/globalConfiguration';
 
@@ -227,7 +227,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
 
         element = child;
 
-        match = checkActive(compatPath)(url)[0];
+        match = findActivePathIndex(compatPath)(url) > -1;
       }
     });
 

--- a/packages/icestark/src/AppRouter.tsx
+++ b/packages/icestark/src/AppRouter.tsx
@@ -7,7 +7,7 @@ import { ICESTSRK_ERROR, ICESTSRK_NOT_FOUND } from './util/constant';
 import start, { unload } from './start';
 import { AppConfig, MicroApp } from './apps';
 import { doPrefetch, Prefetch } from './util/prefetch';
-import findActivePathIndex, { AppRoutePath, formatPath } from './util/checkActive';
+import findActivePath, { AppRoutePath, formatPath } from './util/checkActive';
 import { converArray2String, isFunction, mergeFrameworkBaseToPath } from './util/helpers';
 import type { Fetch } from './util/globalConfiguration';
 
@@ -227,7 +227,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
 
         element = child;
 
-        match = findActivePathIndex(compatPath)(url) > -1;
+        match = !!findActivePath(compatPath)(url);
       }
     });
 

--- a/packages/icestark/src/apps.ts
+++ b/packages/icestark/src/apps.ts
@@ -1,7 +1,7 @@
 import Sandbox, { SandboxConstructor, SandboxProps } from '@ice/sandbox';
 import isEmpty from 'lodash.isempty';
 import { NOT_LOADED, NOT_MOUNTED, LOADING_ASSETS, UNMOUNTED, LOAD_ERROR, MOUNTED } from './util/constant';
-import checkUrlActive, { ActivePath, PathOption, formatPath } from './util/checkActive';
+import findActivePathIndex, { ActivePath, PathOption, formatPath } from './util/checkActive';
 import {
   createSandbox,
   getUrlAssets,
@@ -135,7 +135,7 @@ export function registerMicroApp(appConfig: AppConfig, appLifecyle?: AppLifecylc
 
   const { basename: frameworkBasename } = globalConfiguration;
 
-  const checkActive = checkUrlActive(mergeFrameworkBaseToPath(activePathArray, frameworkBasename));
+  const checkActive = findActivePathIndex(mergeFrameworkBaseToPath(activePathArray, frameworkBasename));
 
   const microApp = {
     status: NOT_LOADED,
@@ -397,8 +397,10 @@ export async function createMicroApp(
 export async function mountMicroApp(appName: string) {
   const appConfig = getAppConfig(appName);
   // check current url before mount
-  if (appConfig && appConfig.checkActive(window.location.href) && appConfig.status !== MOUNTED) {
-    if (appConfig.mount) {
+  const shouldMount = appConfig?.mount && (appConfig?.checkActive(window.location.href) > -1);
+
+  if (shouldMount) {
+    if (appConfig?.mount) {
       await appConfig.mount({ container: appConfig.container, customProps: appConfig.props });
     }
     updateAppConfig(appName, { status: MOUNTED });

--- a/packages/icestark/src/apps.ts
+++ b/packages/icestark/src/apps.ts
@@ -20,7 +20,7 @@ import { ErrorCode, formatErrMessage } from './util/error';
 import globalConfiguration, { temporaryState } from './util/globalConfiguration';
 
 import type { StartConfiguration } from './util/globalConfiguration';
-import type { CheckActiveReturns } from './util/checkActive';
+import type { FindActivePathReturn } from './util/checkActive';
 
 export type ScriptAttributes = string[] | ((url: string) => string[]);
 
@@ -65,7 +65,7 @@ export interface BaseConfig extends PathOption {
   /**
    * @private will be prefixed with `_` for it is internal.
    */
-  findActivePath?: CheckActiveReturns;
+  findActivePath?: FindActivePathReturn;
   appAssets?: Assets;
   props?: object;
   cached?: boolean;

--- a/packages/icestark/src/apps.ts
+++ b/packages/icestark/src/apps.ts
@@ -15,11 +15,12 @@ import {
 import { setCache } from './util/cache';
 import { loadScriptByFetch, loadScriptByImport } from './util/loaders';
 import { getLifecyleByLibrary, getLifecyleByRegister } from './util/getLifecycle';
-import { mergeFrameworkBaseToPath, getAppBasename, shouldSetBasename, log, isDev } from './util/helpers';
+import { mergeFrameworkBaseToPath, getAppBasename, pathData2String, shouldSetBasename, log, isDev } from './util/helpers';
 import { ErrorCode, formatErrMessage } from './util/error';
 import globalConfiguration, { temporaryState } from './util/globalConfiguration';
 
 import type { StartConfiguration } from './util/globalConfiguration';
+import type { CheckActiveReturns } from './util/checkActive';
 
 export type ScriptAttributes = string[] | ((url: string) => string[]);
 
@@ -61,7 +62,10 @@ export interface BaseConfig extends PathOption {
    */
   umd?: boolean;
   loadScriptMode?: LoadScriptMode;
-  checkActive?: (url: string) => boolean;
+  /**
+   * @private will be prefixed with `_` for it is internal.
+   */
+  checkActive?: CheckActiveReturns;
   appAssets?: Assets;
   props?: object;
   cached?: boolean;
@@ -353,7 +357,7 @@ export async function createMicroApp(
     return null;
   }
 
-  const { container, basename, activePath, configuration: userConfiguration } = appConfig;
+  const { container, basename, activePath, configuration: userConfiguration, checkActive } = appConfig;
 
   if (container) {
     setCache('root', container);
@@ -362,7 +366,8 @@ export async function createMicroApp(
   const { basename: frameworkBasename, fetch } = userConfiguration;
 
   if (shouldSetBasename(activePath, basename)) {
-    setCache('basename', getAppBasename(activePath, frameworkBasename, basename));
+    const pathString = pathData2String(activePath, checkActive);
+    setCache('basename', getAppBasename(pathString, frameworkBasename, basename));
   }
 
   switch (appConfig.status) {

--- a/packages/icestark/src/start.ts
+++ b/packages/icestark/src/start.ts
@@ -57,7 +57,7 @@ export function reroute(url: string, type: RouteType | 'init' | 'popstate'| 'has
     const unmountApps = [];
     const activeApps = [];
     getMicroApps().forEach((microApp: AppConfig) => {
-      const shouldBeActive = microApp.checkActive(url);
+      const shouldBeActive = microApp.checkActive(url)[0];
       if (shouldBeActive) {
         activeApps.push(microApp);
       } else {

--- a/packages/icestark/src/start.ts
+++ b/packages/icestark/src/start.ts
@@ -57,7 +57,7 @@ export function reroute(url: string, type: RouteType | 'init' | 'popstate'| 'has
     const unmountApps = [];
     const activeApps = [];
     getMicroApps().forEach((microApp: AppConfig) => {
-      const shouldBeActive = microApp.checkActive(url) > -1;
+      const shouldBeActive = !!microApp.findActivePath(url);
       if (shouldBeActive) {
         activeApps.push(microApp);
       } else {

--- a/packages/icestark/src/start.ts
+++ b/packages/icestark/src/start.ts
@@ -57,7 +57,7 @@ export function reroute(url: string, type: RouteType | 'init' | 'popstate'| 'has
     const unmountApps = [];
     const activeApps = [];
     getMicroApps().forEach((microApp: AppConfig) => {
-      const shouldBeActive = microApp.checkActive(url)[0];
+      const shouldBeActive = microApp.checkActive(url) > -1;
       if (shouldBeActive) {
         activeApps.push(microApp);
       } else {

--- a/packages/icestark/src/util/checkActive.ts
+++ b/packages/icestark/src/util/checkActive.ts
@@ -95,17 +95,16 @@ const findActivePath = (activePath?: PathData[] | ActiveFn): (url?: string) => s
   return (url: string) => {
     // Record matched index
     let matchedPath;
-    const ruleFnc = (path: PathData) => (checkUrl: string) => matchPath(checkUrl, path);
     const isActive = activePath.some((path) => {
       matchedPath = path?.value;
-      return ruleFnc(path)(url);
+      return matchPath(url, path);
     });
 
     return isActive ? matchedPath : false;
   };
 };
 
-export type CheckActiveReturns = ReturnType<typeof findActivePath>;
+export type FindActivePathReturn = ReturnType<typeof findActivePath>;
 
 export default findActivePath;
 

--- a/packages/icestark/src/util/checkActive.ts
+++ b/packages/icestark/src/util/checkActive.ts
@@ -81,33 +81,33 @@ export const formatPath = (activePath?: ActivePath, options: PathOption = {}): P
  * @param activePath
  * @returns
  */
-const findActivePathIndex = (activePath?: PathData[] | ActiveFn): (url?: string) => number => {
+const findActivePath = (activePath?: PathData[] | ActiveFn): (url?: string) => string | boolean => {
   // Always activate app when activePath is not specified.
   if (!activePath) {
-    return () => 0;
+    return () => true;
   }
 
   // If pass fucntion to activePath, just returns
   if (isFunction(activePath)) {
-    return (url: string) => (activePath(url) ? 0 : -1);
+    return (url: string) => activePath(url);
   }
 
   return (url: string) => {
     // Record matched index
-    let recordIdx = 0;
+    let matchedPath;
     const ruleFnc = (path: PathData) => (checkUrl: string) => matchPath(checkUrl, path);
-    const isActive = activePath.some((path, index) => {
-      recordIdx = index;
+    const isActive = activePath.some((path) => {
+      matchedPath = path?.value;
       return ruleFnc(path)(url);
     });
 
-    return isActive ? recordIdx : -1;
+    return isActive ? matchedPath : false;
   };
 };
 
-export type CheckActiveReturns = ReturnType<typeof findActivePathIndex>;
+export type CheckActiveReturns = ReturnType<typeof findActivePath>;
 
-export default findActivePathIndex;
+export default findActivePath;
 
 const HashPathDecoders = {
   hashbang: (path: string) => (path.charAt(0) === '!' ? path.substr(1) : path),

--- a/packages/icestark/src/util/checkActive.ts
+++ b/packages/icestark/src/util/checkActive.ts
@@ -81,15 +81,15 @@ export const formatPath = (activePath?: ActivePath, options: PathOption = {}): P
  * @param activePath
  * @returns
  */
-const checkActive = (activePath?: PathData[] | ActiveFn): (url?: string) => [boolean, number] => {
+const findActivePathIndex = (activePath?: PathData[] | ActiveFn): (url?: string) => number => {
   // Always activate app when activePath is not specified.
   if (!activePath) {
-    return () => [true, 0];
+    return () => 0;
   }
 
   // If pass fucntion to activePath, just returns
   if (isFunction(activePath)) {
-    return (url: string) => [activePath(url), 0];
+    return (url: string) => (activePath(url) ? 0 : -1);
   }
 
   return (url: string) => {
@@ -101,13 +101,13 @@ const checkActive = (activePath?: PathData[] | ActiveFn): (url?: string) => [boo
       return ruleFnc(path)(url);
     });
 
-    return [isActive, recordIdx];
+    return isActive ? recordIdx : -1;
   };
 };
 
-export type CheckActiveReturns = ReturnType<typeof checkActive>;
+export type CheckActiveReturns = ReturnType<typeof findActivePathIndex>;
 
-export default checkActive;
+export default findActivePathIndex;
 
 const HashPathDecoders = {
   hashbang: (path: string) => (path.charAt(0) === '!' ? path.substr(1) : path),

--- a/packages/icestark/src/util/helpers.ts
+++ b/packages/icestark/src/util/helpers.ts
@@ -1,4 +1,4 @@
-import type { PathData, AppRoutePath, ActiveFn, ActivePath } from './checkActive';
+import type { PathData, AppRoutePath, ActiveFn, ActivePath, CheckActiveReturns } from './checkActive';
 
 export const isDev = process.env.NODE_ENV === 'development';
 
@@ -100,9 +100,14 @@ export function addLeadingSlash(path: string): string {
 * It's difficult to dig out the actual path url, so comes the
 * following function.
  */
-export const getActualUrlFromPath = (path: AppRoutePath): string => {
+export const pathData2String = (path: AppRoutePath, checkActive: CheckActiveReturns): string => {
   if (Array.isArray(path)) {
-    return (typeof path[0] === 'string' ? path[0] : path[0].value);
+    // Find the matched index to set basename for microapp
+    const idx = checkActive(window.location.href)[1] ?? 0;
+
+    return typeof path[idx] === 'string'
+      ? path[idx]
+      : (path[idx] as any).value;
   }
   if (isObject<PathData>(path)) {
     return path.value;
@@ -114,8 +119,8 @@ export const getActualUrlFromPath = (path: AppRoutePath): string => {
  * Get basename for micro apps to use handily.
  * A properly formatted basename has a leading slash, but not trailing slash.
  */
-export const getAppBasename = (path: AppRoutePath = '', frameworkBase?: string, appBase?: string): string => {
-  const actualPath = addLeadingSlash(getActualUrlFromPath(path));
+export const getAppBasename = (path = '', frameworkBase?: string, appBase?: string): string => {
+  const actualPath = addLeadingSlash(path);
 
   const leadingSlashFrameworkBase = frameworkBase && addLeadingSlash(frameworkBase);
   const leadingSlashAppBase = appBase && addLeadingSlash(appBase);

--- a/packages/icestark/src/util/helpers.ts
+++ b/packages/icestark/src/util/helpers.ts
@@ -97,39 +97,19 @@ export function addLeadingSlash(path: string): string {
 }
 
 /**
-* It's difficult to dig out the actual path url, so comes the
-* following function.
- */
-export const pathData2String = (path: AppRoutePath, checkActive: CheckActiveReturns): string => {
-  if (Array.isArray(path)) {
-    // Find the matched index to set basename for microapp
-    const idx = checkActive(window.location.href);
-
-    return typeof path[idx] === 'string'
-      ? path[idx]
-      : (path[idx] as any).value;
-  }
-  if (isObject<PathData>(path)) {
-    return path.value;
-  }
-  return path;
-};
-
-/**
  * Get basename for micro apps to use handily.
  * A properly formatted basename has a leading slash, but not trailing slash.
  */
-export const getAppBasename = (path = '', frameworkBase?: string, appBase?: string): string => {
+export const getAppBasename = (path = '', appBase?: string): string => {
   const actualPath = addLeadingSlash(path);
 
-  const leadingSlashFrameworkBase = frameworkBase && addLeadingSlash(frameworkBase);
   const leadingSlashAppBase = appBase && addLeadingSlash(appBase);
 
   /**
   * It's preferable to use `??` bewteen leadingSlashAppBase and actualPath. But some
   * users already use the misunderstanding `basename=''`, which we have to keep things the way they are.
    */
-  return `${leadingSlashFrameworkBase}${leadingSlashAppBase || actualPath}`;
+  return `${leadingSlashAppBase || actualPath}`;
 };
 
 /**

--- a/packages/icestark/src/util/helpers.ts
+++ b/packages/icestark/src/util/helpers.ts
@@ -103,7 +103,7 @@ export function addLeadingSlash(path: string): string {
 export const pathData2String = (path: AppRoutePath, checkActive: CheckActiveReturns): string => {
   if (Array.isArray(path)) {
     // Find the matched index to set basename for microapp
-    const idx = checkActive(window.location.href)[1] ?? 0;
+    const idx = checkActive(window.location.href);
 
     return typeof path[idx] === 'string'
       ? path[idx]

--- a/packages/icestark/src/util/helpers.ts
+++ b/packages/icestark/src/util/helpers.ts
@@ -1,4 +1,4 @@
-import type { PathData, AppRoutePath, ActiveFn, ActivePath, CheckActiveReturns } from './checkActive';
+import type { PathData, AppRoutePath, ActiveFn, ActivePath, FindActivePathReturn } from './checkActive';
 
 export const isDev = process.env.NODE_ENV === 'development';
 

--- a/website/docs/api/ice-stark.md
+++ b/website/docs/api/ice-stark.md
@@ -74,7 +74,6 @@ interface AppConfig {
   basename?: string;
   umd?: boolean;
   loadScriptMode?: 'fetch' | 'script' | 'import';
-  checkActive?: (url: string) => boolean;
   appAssets?: Assets;
   props?: object;
   cached?: boolean;


### PR DESCRIPTION
✅ Closes: #526