### PR TITLE
Fix/prefetch block

### DIFF
--- a/packages/icestark/src/AppRoute.tsx
+++ b/packages/icestark/src/AppRoute.tsx
@@ -146,7 +146,8 @@ export default class AppRoute extends React.Component<AppRouteProps, AppRouteSta
     if (this.validateRender()) {
       this.setState({ showComponent: true });
     } else {
-      this.renderChild();
+      // 使用requestIdleCallback渲染子应用，可避免在预加载场景下，因executeScript中的eval函数执行js脚本，而导致的进程阻塞及页面卡顿
+      window.requestIdleCallback(() => this.renderChild());
     }
   };
 

--- a/packages/icestark/src/AppRouter.tsx
+++ b/packages/icestark/src/AppRouter.tsx
@@ -47,7 +47,9 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
   static defaultProps = {
     onRouteChange: () => {},
     // eslint-disable-next-line react/jsx-filename-extension
-    ErrorComponent: ({ err }: { err: string | Error}) => <div>{ typeof err === 'string' ? err : err?.message }</div>,
+    ErrorComponent: ({ err }: { err: string | Error }) => (
+      <div>{typeof err === 'string' ? err : err?.message}</div>
+    ),
     LoadingComponent: <div>Loading...</div>,
     NotFoundComponent: <div>NotFound</div>,
     onAppEnter: () => {},
@@ -90,10 +92,10 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
      * status `started` used to make sure parent's `componentDidMount` to be invoked eariler then child's,
      * for mounting child component needs global configuration be settled.
      */
-    const { shouldAssetsRemove, onAppEnter, onAppLeave, fetch, basename } = this.props;
+    const { shouldAssetsRemove, onAppLeave, fetch, basename } = this.props;
     start({
       onAppLeave,
-      onAppEnter,
+      onAppEnter: this.appEnter,
       onLoadingApp: this.loadingApp,
       onFinishLoading: this.finishLoading,
       onError: this.triggerError,
@@ -130,7 +132,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
               ...childElement.props,
               /**
                * name of AppRoute may be not provided, use `path` instead.
-              */
+               */
               name: name || converArray2String(path),
             };
           }
@@ -170,6 +172,13 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
 
       const { pathname, query, hash } = urlParse(url, true);
       this.props.onRouteChange(pathname, query, hash, type);
+    }
+  };
+
+  appEnter = (app: AppConfig) => {
+    this.props.onAppEnter(app);
+    if (!!this.props.prefetch) {
+      this.setState({ appLoading: app.name });
     }
   };
 
@@ -256,7 +265,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
             name: this.appKey,
             componentProps,
             cssLoading: appLoading === this.appKey,
-            onAppEnter: this.props.onAppEnter,
+            onAppEnter: this.appEnter,
             onAppLeave: this.props.onAppLeave,
           })}
         </div>

--- a/packages/icestark/src/AppRouter.tsx
+++ b/packages/icestark/src/AppRouter.tsx
@@ -178,6 +178,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
   appEnter = (app: AppConfig) => {
     this.props.onAppEnter(app);
     if (!!this.props.prefetch) {
+      // 预加载场景需要将loading提升，否则会由于脚本阻塞进程，导致loading失效
       this.setState({ appLoading: app.name });
     }
   };


### PR DESCRIPTION
问题描述： 项目使用了预加载功能，在点击导航栏切换子应用时，由于executeScript中的eval函数执行js脚本，导致点击行为阻塞，直至js脚本执行完毕后，点击行为才结束，导致页面出现明显的卡顿现象；chrome performance分析如下：
![image](https://user-images.githubusercontent.com/44611361/217250280-124473d8-aa8b-4a56-9956-c48c98e6538d.png)


解决办法：通过requestIdleCallback渲染子应用，确保项目内状态更新完成后，再去渲染子应用