### PR TITLE
docs: fix typos in documents

### DIFF
--- a/website/docs/guide/advanced/performance.md
+++ b/website/docs/guide/advanced/performance.md
@@ -40,7 +40,7 @@ start({
 `prefetch` 值支持三种形式：
 
 + **布尔值**：当 `prefetch` 为 `true` 时，所以微应用资源均会被 `prefetch`;
-+ **数组**：当传入值为 `name` 的数组时，只要数组中的微应用资源会被 `prefetch`;
++ **数组**：当传入值为 `name` 的数组时，只有数组中的微应用资源会被 `prefetch`;
 
 ```js
 start({


### PR DESCRIPTION
「要」 改为 「有」
<img width="658" alt="image" src="https://github.com/ice-lab/icestark/assets/31138343/16a88f09-7ca5-459a-9f85-23f9a4fb5390">