### PR TITLE
修复 icestark App router prefetch 功能

### DIFF
--- a/packages/icestark/package.json
+++ b/packages/icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/stark",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "Icestark is a JavaScript library for multiple projects, Ice workbench solution.",
   "scripts": {
     "build": "rm -rf lib && tsc",

--- a/packages/icestark/src/AppRouter.tsx
+++ b/packages/icestark/src/AppRouter.tsx
@@ -35,6 +35,8 @@ export interface AppRouterProps {
   basename?: string;
   fetch?: Fetch;
   prefetch?: Prefetch;
+  apps?: AppConfig;
+  children?: React.ReactChildren;
 }
 
 interface AppRouterState {
@@ -74,11 +76,7 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
       started: false,
     };
 
-    const { fetch, prefetch: strategy, children } = props;
-
-    if (strategy) {
-      this.prefetch(strategy, children, fetch);
-    }
+    this.tryPrefetch(props);
   }
 
   componentDidMount() {
@@ -111,6 +109,24 @@ export default class AppRouter extends React.Component<AppRouterProps, AppRouter
     window.removeEventListener('icestark:not-found', this.triggerNotFound);
     unload();
     this.setState({ started: false });
+  }
+
+  componentWillReceiveProps(nextProps: Readonly<AppRouterProps>, nextContext: any): void {
+    if (nextProps.apps !== this.props.apps) {
+      this.tryPrefetch(nextProps);
+    }
+  }
+
+  /**
+   * try to prefetch again
+   * @param props 
+   */
+  tryPrefetch(props: AppRouterProps): void {
+    const { fetch, prefetch: strategy, children } = props;
+
+    if (strategy) {
+      this.prefetch(strategy, children, fetch);
+    }
   }
 
   /**


### PR DESCRIPTION
现象：配置 approuter prefetch 后，实际未预加载微应用 router 相关资源
原因定位：AppRouter 内部在 construct 时，解析 React.children，进行微应用的 prefetch，这要求在 AppRouter 在构建时就需要提供所有微应用的 child。
修复方式：修改 @ice/plugin-icestark 插件中，对 AppRouter 的渲染方式，传入 apps，在 AppRouter 中，判定 apps 变化，做 prefetch。

---

构造方法时 prefetch
https://github.com/ice-lab/icestark/blob/master/packages/icestark/src/AppRouter.tsx#L79

![image](https://github.com/ice-lab/icestark/assets/13255714/89f2f454-ec2d-4db7-a077-65a6cdc0555f)

依赖 child
https://github.com/ice-lab/icestark/blob/master/packages/icestark/src/AppRouter.tsx#L121
![image](https://github.com/ice-lab/icestark/assets/13255714/dd9705fd-a99b-4693-b3ab-5ca8f862a21b)



插件渲染时机
https://github.com/alibaba/ice/blob/master/packages/plugin-icestark/src/runtime/framework.tsx#L48
![image](https://github.com/ice-lab/icestark/assets/13255714/fcec6aa4-84f0-4a0b-80c3-8250c84f3b78)
![image](https://github.com/ice-lab/icestark/assets/13255714/fba454b5-a798-41b7-bb4d-54885ec1a62c)


