### PR TITLE
fix: automatically switch to fetch mode when runtime is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See [https://github.com/ice-lab/icestark/releases](https://github.com/ice-lab/icestark/releases) for what has changed in each version of icestark.
 
+# 2.8.4
+
+- [fix] automatically switch to "fetch" mode when runtime is set.
+
 # 2.8.3
 
 - [feat] support `runtime.url` as an array for loading multiple types of resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [https://github.com/ice-lab/icestark/releases](https://github.com/ice-lab/ic
 # 2.8.4
 
 - [fix] automatically switch to "fetch" mode when runtime is set.
+- [fix] improve runtime asset handling when runtime is loaded.
 
 # 2.8.3
 

--- a/packages/icestark/package.json
+++ b/packages/icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/stark",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Icestark is a JavaScript library for multiple projects, Ice workbench solution.",
   "scripts": {
     "build": "rm -rf lib && tsc",

--- a/packages/icestark/src/AppRoute.tsx
+++ b/packages/icestark/src/AppRoute.tsx
@@ -90,7 +90,7 @@ export default class AppRoute extends React.Component<AppRouteProps, AppRouteSta
       if (loadScriptMode && loadScriptMode !== 'fetch') {
         console.error('[icestark] runtime option can only be used when loadScriptMode is set to "fetch"');
       } else if (!loadScriptMode) {
-        console.warn('[icestark] Runtime option detected but loadScriptMode not set - automatically switching to "fetch" mode');
+        console.log('[icestark] Runtime option detected but loadScriptMode not set - automatically switching to "fetch" mode');
       }
     }
   }

--- a/packages/icestark/src/AppRoute.tsx
+++ b/packages/icestark/src/AppRoute.tsx
@@ -86,8 +86,12 @@ export default class AppRoute extends React.Component<AppRouteProps, AppRouteSta
     };
     const { loadScriptMode, runtime } = props;
 
-    if (loadScriptMode && loadScriptMode !== 'fetch' && runtime) {
-      console.error('[icestark] runtime option can only be used when loadScriptMode is set to "fetch"');
+    if (runtime) {
+      if (loadScriptMode && loadScriptMode !== 'fetch') {
+        console.error('[icestark] runtime option can only be used when loadScriptMode is set to "fetch"');
+      } else if (!loadScriptMode) {
+        console.warn('[icestark] Runtime option detected but loadScriptMode not set - automatically switching to "fetch" mode');
+      }
     }
   }
 

--- a/packages/icestark/src/apps.ts
+++ b/packages/icestark/src/apps.ts
@@ -218,7 +218,7 @@ export async function loadAppModule(appConfig: AppConfig) {
       const runtimeJsList = [];
       // Filter and map runtime libraries that haven't been registered in window
       const runtimeLibs = runtime?.filter((config) => {
-        return config.version && config.library && !window[`${config.library}@${config.version}`];
+        return config.version && config.library;
       }).map((config) => {
         // Handle both string and array URL formats
         const urls = Array.isArray(config.url) ? config.url : [config.url];
@@ -250,6 +250,7 @@ export async function loadAppModule(appConfig: AppConfig) {
         return {
           content: mainJs,
           type: AssetTypeEnum.RUNTIME,
+          loaded: Boolean(config.version && config.library && window[`${config.library}@${config.version}`]),
           library: config.library,
           version: config.version,
         };

--- a/packages/icestark/src/apps.ts
+++ b/packages/icestark/src/apps.ts
@@ -374,14 +374,14 @@ function mergeThenUpdateAppConfig(name: string, configuration?: StartConfigurati
     return;
   }
 
-  const { umd, sandbox } = appConfig;
+  const { umd, sandbox, runtime } = appConfig;
 
   // Generate appSandbox
   const appSandbox = createSandbox(sandbox) as Sandbox;
 
   // Merge loadScriptMode
   const sandboxEnabled = sandbox && !appSandbox.sandboxDisabled;
-  const loadScriptMode = appConfig.loadScriptMode ?? (umd || sandboxEnabled ? 'fetch' : 'script');
+  const loadScriptMode = appConfig.loadScriptMode ?? (umd || sandboxEnabled || (runtime && runtime.length > 0) ? 'fetch' : 'script');
 
   // Merge global configuration
   const cfgs = {


### PR DESCRIPTION
This pull request introduces a new feature to automatically switch to "fetch" mode when the `runtime` option is set, along with related updates to improve functionality and documentation. The changes primarily focus on enhancing the handling of the `runtime` option in script loading and updating relevant files to reflect the new version.